### PR TITLE
Allow etcd-mesos to be detected by an etcd proxy

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -642,8 +642,6 @@ func (s *EtcdScheduler) launchOne(driver scheduler.SchedulerDriver) {
 	rpcPort := lowest
 	clientPort := lowest + 1
 
-	s.highestInstanceID++
-
 	s.mut.Lock()
 	var clusterType string
 	if len(s.running) == 0 {
@@ -652,7 +650,9 @@ func (s *EtcdScheduler) launchOne(driver scheduler.SchedulerDriver) {
 		clusterType = "existing"
 	}
 
+	s.highestInstanceID++
 	name := "etcd-" + strconv.FormatInt(s.highestInstanceID, 10)
+
 	node := &config.Node{
 		Name:       name,
 		Host:       *offer.Hostname,
@@ -683,7 +683,7 @@ func (s *EtcdScheduler) launchOne(driver scheduler.SchedulerDriver) {
 	executor := s.newExecutorInfo(node, s.executorUris)
 	task := &mesos.TaskInfo{
 		Data:     serializedNodes,
-		Name:     proto.String(name),
+		Name:     proto.String("etcd-server"),
 		TaskId:   taskID,
 		SlaveId:  offer.SlaveId,
 		Executor: executor,


### PR DESCRIPTION
@tsenart @jdef 
This is a "this is how it works" PR...

When you pass -discovery-srv=something to etcd, it will query these srv records to determine hosts to connect to:

```
_etcd-server-ssl._tcp.something
_etcd-server._tcp.something
```

This simple change allows us to run etcd proxy nodes anywhere we want, and they will follow along to the cluster membership mutations.

One failure case we may want to get a patch into upstream etcd for is to re-resolve the srv record when it fails to reconnect to all known hosts.  I've opened https://github.com/coreos/etcd/issues/3177 that deals with this.  In testing, I realized there's a bug with etcd when it runs in proxy mode where it is only able to detect mutations of cluster membership, but not a replacement srv record.  This means that if we ever have a catastrophic re-seed event (above n/2 simultaneous etcd failures) that we will also need to restart all proxies.  

In practice we can work around this, but it means a little more work for our k8s mega-instance.  The simplest way would be to terminate the mega-instance, which will force a re-resolution by virtue of creating a new proxy.  This will only be feasible when all k8s components re-resolve the known apiserver etc...  Until then we may want to reboot the proxy in the same mega-instance when it returns a 501 for a few seconds in a row.

I've tested this by throwing up a mesos cluster, running mesos-dns on it, setting /etc/resolv.conf to use the mesos-dns host as the first nameserver, then:

```
./etcd-scheduler -cluster-name="somecluster" &
etcd  --proxy=on --discovery-srv=etcd-somecluster.mesos &
etcdctl set /test `date +%s`

for slave in $MESOS_SLAVES; do
  # kill the slave and etcd
  etcdctl get /test
  # ensure we get the last written value
  etctctl set /test `date +%s`
  # restart the mesos slave
  # wait a few moments for the scheduler to finish bringing up a replacement
done
```
