### PR TITLE
resource allocation-related fixes, etc

### DIFF
--- a/cmd/etcd-mesos-executor/app.go
+++ b/cmd/etcd-mesos-executor/app.go
@@ -48,7 +48,7 @@ func main() {
 	if libprocessIP := os.Getenv("LIBPROCESS_IP"); libprocessIP != "" {
 		address = net.ParseIP(libprocessIP)
 		if address == nil {
-			log.Warning("failed to parse IP address from LIBPROCESS_IP envvar %q", libprocessIP)
+			log.Warningf("failed to parse IP address from LIBPROCESS_IP envvar %q", libprocessIP)
 		}
 	}
 	dconfig := executor.DriverConfig{

--- a/cmd/etcd-mesos-executor/app.go
+++ b/cmd/etcd-mesos-executor/app.go
@@ -20,6 +20,8 @@ package main
 
 import (
 	"flag"
+	"net"
+	"os"
 	"time"
 
 	log "github.com/golang/glog"
@@ -29,15 +31,29 @@ import (
 )
 
 func main() {
-	launchTimeout :=
-		flag.Uint("launch-timeout", 240,
+	var (
+		launchTimeout = flag.Uint("launch-timeout", 240,
 			"Seconds to retry launching an etcd instance for before giving up. "+
 				"This should be long enough for a port occupied by a killed process "+
 				"to be vacated.")
+		driverPort = flag.Uint("driver-port", 0, "Libprocess port for the executor driver")
+	)
 	flag.Parse()
+	if *driverPort == 0 {
+		log.Fatal("missing or incorrectly specified driver-port flag, must be > 0")
+	}
 	log.Infoln("Starting etcd Executor")
 
+	var address net.IP
+	if libprocessIP := os.Getenv("LIBPROCESS_IP"); libprocessIP != "" {
+		address = net.ParseIP(libprocessIP)
+		if address == nil {
+			log.Warning("failed to parse IP address from LIBPROCESS_IP envvar %q", libprocessIP)
+		}
+	}
 	dconfig := executor.DriverConfig{
+		BindingAddress: address,
+		BindingPort:    uint16(*driverPort),
 		Executor: etcdexecutor.New(
 			time.Duration(*launchTimeout) * time.Second,
 		),

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -199,7 +199,7 @@ func (e *Executor) etcdHarness(
 	}
 	_, err = driver.SendStatusUpdate(runStatus)
 	if err != nil {
-		log.Errorf("Got error sending status update, terminating: ", err)
+		log.Errorf("Got error sending status update, terminating: %v", err)
 		handleFailure(driver, taskInfo)
 	}
 

--- a/offercache/offercache_test.go
+++ b/offercache/offercache_test.go
@@ -44,7 +44,7 @@ func TestPush(t *testing.T) {
 			oc.Push(newOffer(o, o))
 		}
 		if got := oc.Len(); got != tt.want {
-			t.Errorf("test #%d: got : %s, want: %s", i, got, tt.want)
+			t.Errorf("test #%d: got : %d, want: %d", i, got, tt.want)
 		}
 	}
 }
@@ -71,7 +71,7 @@ func TestRescind(t *testing.T) {
 			oc.Rescind(util.NewOfferID(r))
 		}
 		if got := oc.Len(); got != tt.want {
-			t.Errorf("test #%d: got : %s, want: %s", i, got, tt.want)
+			t.Errorf("test #%d: got : %d, want: %d", i, got, tt.want)
 		}
 	}
 
@@ -117,7 +117,7 @@ func TestBlockingPop(t *testing.T) {
 		}()
 
 		if got != tt.want {
-			t.Errorf("test #%d: got : %s, want: %s", i, got, tt.want)
+			t.Errorf("test #%d: got : %d, want: %d", i, got, tt.want)
 		}
 	}
 }

--- a/scheduler/mock_test.go
+++ b/scheduler/mock_test.go
@@ -151,7 +151,12 @@ func (m *MockSchedulerDriver) Wait() {
 	defer m.Unlock()
 	m.Called()
 }
-
+func (m *MockSchedulerDriver) AcceptOffers(offerIDs []*mesos.OfferID, operations []*mesos.Offer_Operation, filters *mesos.Filters) (mesos.Status, error) {
+	m.Lock()
+	defer m.Unlock()
+	args := m.Called(offerIDs, operations, filters)
+	return status(args, 0), args.Error(1)
+}
 func status(args mock.Arguments, at int) (val mesos.Status) {
 	if x := args.Get(at); x != nil {
 		val = x.(mesos.Status)


### PR DESCRIPTION
* fixes #92: properly allocate libprocess port for executor driver
* fix resource allocation to take into account executor resources
* executor should attempt to use LIBPROCESS_IP as binding address for compat on multihomed hosts
* don't launch the executor in shell mode: it's a simple command w/ a simple set of args
* fix some govet and `make test` errors