### PR TITLE
Add exteriorAddress flag to handle BRIDGE networks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV CPU_LIMIT=1
 ENV MEM_LIMIT=1024
 CMD sh -xc '/work/bin/etcd-mesos-scheduler -alsologtostderr=true \
     -address=${LIBPROCESS_IP} \
+    -exteriorAddress=${HOST} \
     -framework-name=${FRAMEWORK_NAME} \
     -cluster-size=${CLUSTER_SIZE} \
     -master=${MESOS_MASTER} \

--- a/cmd/etcd-mesos-scheduler/app.go
+++ b/cmd/etcd-mesos-scheduler/app.go
@@ -83,6 +83,8 @@ func main() {
 		flag.String("etcdctl-bin", "./bin/etcdctl", "Path to etcdctl binary")
 	address :=
 		flag.String("address", "", "Binding address for scheduler and artifact server")
+	exteriorAddress :=
+		flag.String("exteriorAddress", "", "Address for agents to request executor binary")
 	driverPort :=
 		flag.Int("driver-port", 0, "Binding port for scheduler driver")
 	mesosAuthPrincipal :=
@@ -127,7 +129,7 @@ func main() {
 	}
 
 	executorUris := []*mesos.CommandInfo_URI{}
-	execUri, err := etcdscheduler.ServeExecutorArtifact(*executorPath, *address, *artifactPort)
+	execUri, err := etcdscheduler.ServeExecutorArtifact(*executorPath, *exteriorAddress, *artifactPort)
 	if err != nil {
 		log.Errorf("Could not stat executor binary: %v", err)
 		return
@@ -136,7 +138,7 @@ func main() {
 		Value:      execUri,
 		Executable: proto.Bool(true),
 	})
-	etcdUri, err := etcdscheduler.ServeExecutorArtifact(*etcdPath, *address, *artifactPort)
+	etcdUri, err := etcdscheduler.ServeExecutorArtifact(*etcdPath, *exteriorAddress, *artifactPort)
 	if err != nil {
 		log.Errorf("Could not stat etcd binary: %v", err)
 		return
@@ -145,7 +147,7 @@ func main() {
 		Value:      etcdUri,
 		Executable: proto.Bool(true),
 	})
-	etcdctlUri, err := etcdscheduler.ServeExecutorArtifact(*etcdctlPath, *address, *artifactPort)
+	etcdctlUri, err := etcdscheduler.ServeExecutorArtifact(*etcdctlPath, *exteriorAddress, *artifactPort)
 	if err != nil {
 		log.Errorf("Could not stat etcd binary: %v", err)
 		return


### PR DESCRIPTION
In cases where the Docker daemon puts containers behind a NAT, the agent needs to use a different address to the address that is bound on to get the executor and related binaries. This change adds an 'exteriorAddress' flag that allow you to specify this.

I would have loved to call this flag address, and move the current address flag to bind-address or something, but I don't know how compatible that would be?