### PR TITLE
Allow authentication to clusters

### DIFF
--- a/cmd/etcd-mesos-scheduler/app.go
+++ b/cmd/etcd-mesos-scheduler/app.go
@@ -81,6 +81,10 @@ func main() {
 		flag.String("etcd-bin", "./bin/etcd", "Path to etcd binary")
 	etcdctlPath :=
 		flag.String("etcdctl-bin", "./bin/etcdctl", "Path to etcdctl binary")
+	etcdUsername :=
+		flag.String("etcd-username", "", "Username to use when querying etcd")
+	etcdPassword :=
+		flag.String("etcd-password", "", "Password to use when querying etcd")
 	address :=
 		flag.String("address", "", "Binding address for scheduler and artifact server")
 	driverPort :=
@@ -173,7 +177,10 @@ func main() {
 		*sandboxDisk,
 		*sandboxCpu,
 		*sandboxMem,
-		*mesosOfferRefuseSeconds)
+		*mesosOfferRefuseSeconds,
+		*etcdUsername,
+		*etcdPassword,
+	)
 	etcdScheduler.ExecutorPath = *executorPath
 	etcdScheduler.Master = *master
 	etcdScheduler.FrameworkName = *frameworkName

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ type Node struct {
 	ReseedPort uint64 `json:"httpPort"`
 	Type       string `json:"type"`
 	SlaveID    string `json:"slaveID"`
+	Username   string `json:"username"`
+	Password   string `json:"password"`
 }
 
 // ErrUnmarshal is returned whenever config unmarshalling
@@ -42,10 +44,10 @@ var ErrUnmarshal = errors.New("config: unmarshaling failed")
 // Parse attempts to deserialize a config.Node from a byte array.
 func Parse(text string) (*Node, error) {
 	fs := strings.Fields(string(text))
-	if len(fs) != 5 {
+	if len(fs) != 7 {
 		return nil, ErrUnmarshal
 	}
-	n := &Node{Name: fs[0], Host: fs[1]}
+	n := &Node{Name: fs[0], Host: fs[1], Username: fs[5], Password: fs[7]}
 
 	var err error
 	if n.RPCPort, err = strconv.ParseUint(fs[2], 10, 64); err != nil {
@@ -63,5 +65,5 @@ func Parse(text string) (*Node, error) {
 // string representation of a Node.
 func (n Node) String() string {
 	return fmt.Sprintf(
-		"%s %s %d %d %d", n.Name, n.Host, n.RPCPort, n.ClientPort, n.ReseedPort)
+		"%s %s %d %d %d %s %s", n.Name, n.Host, n.RPCPort, n.ClientPort, n.ReseedPort, n.Username, n.Password)
 }

--- a/rpc/healthcheck.go
+++ b/rpc/healthcheck.go
@@ -42,6 +42,7 @@ func HealthCheck(running map[string]*config.Node) error {
 		return nil
 	}
 	var validEndpoint string
+	var validNode *config.Node
 	for _, args := range running {
 		url := fmt.Sprintf(
 			"http://%s:%d",
@@ -72,6 +73,7 @@ func HealthCheck(running map[string]*config.Node) error {
 			continue
 		}
 		validEndpoint = url
+		validNode = args
 		break
 	}
 
@@ -83,6 +85,9 @@ func HealthCheck(running map[string]*config.Node) error {
 	// This has a 1s dial timeout, which is ok for us
 	client := etcd.NewClient([]string{validEndpoint})
 	client.SetDialTimeout(RPC_TIMEOUT)
+	if validNode.Username != "" {
+		client.SetCredentials(validNode.Username, validNode.Password)
+	}
 	if ok := client.SyncCluster(); !ok {
 		log.Errorf("Could not establish connection "+
 			"with cluster using endpoints %s", validEndpoint)

--- a/rpc/reseed.go
+++ b/rpc/reseed.go
@@ -63,6 +63,9 @@ func RankReseedCandidates(running map[string]*config.Node) []nodeIndex {
 		)
 		// This has a 1s dial timeout, which is good for us here
 		client := etcd.NewClient([]string{url})
+		if args.Username != "" {
+			client.SetCredentials(args.Username, args.Password)
+		}
 		if ok := client.SyncCluster(); !ok {
 			log.Error("Could not establish connection "+
 				"with cluster using endpoints %+v", url)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -110,6 +110,8 @@ type EtcdScheduler struct {
 	livelockWindow               *time.Time
 	reseeding                    int32
 	reconciliationInfo           map[string]string
+	etcdUsername                 string
+	etcdPassword                 string
 }
 
 type Stats struct {
@@ -139,6 +141,8 @@ func NewEtcdScheduler(
 	cpusPerTask float64,
 	memPerTask float64,
 	offerRefuseSeconds float64,
+	etcdUsername string,
+	etcdPassword string,
 ) *EtcdScheduler {
 	return &EtcdScheduler{
 		Stats: Stats{
@@ -172,6 +176,8 @@ func NewEtcdScheduler(
 		memPerTask:                   memPerTask,
 		offerRefuseSeconds:           offerRefuseSeconds,
 		reconciliationInfo:           map[string]string{},
+		etcdUsername:                 etcdUsername,
+		etcdPassword:                 etcdPassword,
 	}
 }
 
@@ -924,6 +930,8 @@ func (s *EtcdScheduler) launchOne(driver scheduler.SchedulerDriver) {
 		ReseedPort: httpPort,
 		Type:       clusterType,
 		SlaveID:    offer.GetSlaveId().GetValue(),
+		Username:   s.etcdUsername,
+		Password:   s.etcdPassword,
 	}
 	running := []*config.Node{node}
 	for _, r := range s.running {


### PR DESCRIPTION
Enabling auth on the cluster was previously causing the health checks to fail, as the etcd client was not setting credentials. This adds a `Username` and `Password` to `config.Node`, and uses those (if set) to auth to the cluster