### PR TITLE
Move container base image to Alpine Linux 3.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM alpine:3.5
 
 ADD bin /work/bin
 ADD static /work/static

--- a/Makefile
+++ b/Makefile
@@ -38,19 +38,19 @@ build: build_scheduler build_executor build_proxy build_etcd
 .SILENT: build_scheduler
 build_scheduler: bin
 	echo "Building etcd-mesos-scheduler.."
-	go build -o bin/etcd-mesos-scheduler ./cmd/etcd-mesos-scheduler
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags '-w -extldflags=-static' -o bin/etcd-mesos-scheduler ./cmd/etcd-mesos-scheduler
 
 .PHONY: build_executor
 .SILENT: build_executor
 build_executor: bin
 	echo "Building etcd-mesos-executor.."
-	go build -o bin/etcd-mesos-executor ./cmd/etcd-mesos-executor
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags '-w -extldflags=-static' -o bin/etcd-mesos-executor ./cmd/etcd-mesos-executor
 
 .PHONY: build_proxy
 .SILENT: build_proxy
 build_proxy: bin
 	echo "Building etcd-mesos-proxy.."
-	go build -o bin/etcd-mesos-proxy ./cmd/etcd-mesos-proxy
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags '-w -extldflags=-static' -o bin/etcd-mesos-proxy ./cmd/etcd-mesos-proxy
 
 .PHONY: build_etcd
 .SILENT: build_etcd


### PR DESCRIPTION
Refs #94
Fixes #114

Compare the security scan of the original `FROM debian` to `FROM alpine:3.5` below.

**Debian**:
![screen shot 2017-04-20 at 21 35 58](https://cloud.githubusercontent.com/assets/1752631/25305873/229551f4-2738-11e7-9505-db3c4e0e5ec4.png)

**Alpine Linux**:
<img width="985" alt="screen shot 2017-04-22 at 08 16 37" src="https://cloud.githubusercontent.com/assets/1752631/25305876/257ea5c8-2738-11e7-9f71-1da881bdc353.png">

Also, the image size went down from **192MB** to **59MB**.