### PR TITLE
Remove deprecated safety.

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -349,12 +349,6 @@ func (s *EtcdScheduler) StatusUpdate(
 
 		atomic.AddUint32(&s.Stats.FailedServers, 1)
 
-		// TODO(tyler) kill this
-		// Pump the brakes so that we have time to deconfigure the lost node
-		// before adding a new one.  If we don't deconfigure first, we risk
-		// split brain.
-		s.PumpTheBrakes()
-
 		// now we know this task is dead
 		delete(s.pending, node.Name)
 		delete(s.running, node.Name)
@@ -620,14 +614,6 @@ func (s *EtcdScheduler) QueueLaunchAttempt() {
 	default:
 		// Somehow launchChan is full...
 		log.Warning("launchChan is full!")
-	}
-}
-
-func (s *EtcdScheduler) PumpTheBrakes() {
-	select {
-	case s.pauseChan <- struct{}{}:
-	default:
-		log.Warning("pauseChan is full!")
 	}
 }
 


### PR DESCRIPTION
Fixes #56

Performed the following tests:
- [x] (a) start up an etcd cluster; make sure that the number of expected servers is brought online
- [x] (b) kill a server, make sure that etcd-mesos brings it back online
- [x] (c) kill a node; make sure that etcd-mesos can cope with that (assuming that normal cluster size is >= 3 servers)
- [ ] ~~(d) bring the node back online; etcd should launch a server on it~~